### PR TITLE
Changed #foreign user32 to gdi32 where this was wrong.

### DIFF
--- a/core/sys/windows.odin
+++ b/core/sys/windows.odin
@@ -394,9 +394,9 @@ PIXELFORMATDESCRIPTOR :: struct #ordered {
 }
 
 GetDC             :: proc(h: HANDLE) -> HDC #foreign user32;
-SetPixelFormat    :: proc(hdc: HDC, pixel_format: i32, pfd: ^PIXELFORMATDESCRIPTOR ) -> BOOL #foreign user32;
-ChoosePixelFormat :: proc(hdc: HDC, pfd: ^PIXELFORMATDESCRIPTOR) -> i32 #foreign user32;
-SwapBuffers       :: proc(hdc: HDC) -> BOOL #foreign user32;
+SetPixelFormat    :: proc(hdc: HDC, pixel_format: i32, pfd: ^PIXELFORMATDESCRIPTOR ) -> BOOL #foreign gdi32;
+ChoosePixelFormat :: proc(hdc: HDC, pfd: ^PIXELFORMATDESCRIPTOR) -> i32 #foreign gdi32;
+SwapBuffers       :: proc(hdc: HDC) -> BOOL #foreign gdi32;
 ReleaseDC         :: proc(wnd: HWND, hdc: HDC) -> i32 #foreign user32;
 
 WGL_CONTEXT_MAJOR_VERSION_ARB             :: 0x2091;


### PR DESCRIPTION
Some of the procedures in sys/windows.odin had the wrong foreign library attached to them. Simple fix.

- thebirk/badflydog