### PR TITLE
Building in linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,8 @@
 
 release_mode=0
 
-warnings_to_disable="-std=c11 -Wno-switch -Wno-pointer-sign -Wno-tautological-constant-out-of-range-compare -Wno-tautological-compare -Wno-macro-redefined"
-libraries="-pthread -ldl -lm"
+warnings_to_disable="-std=c++11 -g -Wno-switch -Wno-pointer-sign -Wno-tautological-constant-out-of-range-compare -Wno-tautological-compare -Wno-macro-redefined -Wno-writable-strings -Wno-attributes -Wno-write-strings"
+libraries="-pthread -ldl -lm -lstdc++"
 other_args=""
 compiler="clang"
 
@@ -19,6 +19,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
 	other_args="${other_args} -liconv"
 fi
 
-${compiler} src/main.c ${warnings_to_disable} ${libraries} ${other_args} -o odin
+${compiler} src/main.cpp ${warnings_to_disable} ${libraries} ${other_args} -o odin
 
 ./odin run code/demo.odin

--- a/core/os.odin
+++ b/core/os.odin
@@ -1,5 +1,5 @@
 import_load {
-	"os_windows.odin" when ODIN_OS == "windows";
+	//"os_windows.odin" when ODIN_OS == "windows";
 	"os_x.odin"       when ODIN_OS == "osx";
 	"os_linux.odin"   when ODIN_OS == "linux";
 }

--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -141,7 +141,7 @@ String odin_root_dir(void) {
 
 String odin_root_dir(void) {
 	String path = global_module_path;
-	Array(char) path_buf;
+	Array<char> path_buf;
 	isize len, i;
 	gbTempArenaMemory tmp;
 	u8 *text;

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -2144,9 +2144,9 @@ irValue *ir_emit_arith(irProcedure *proc, TokenKind op, irValue *left, irValue *
 		bool is_unsigned = is_type_unsigned(type);
 		char *name = NULL;
 		if (op == Token_Quo) {
-			name = is_unsigned ? "__udivti3" : "__divti3";
+			name = (char*)(is_unsigned ? "__udivti3" : "__divti3");
 		} else if (op == Token_Mod) {
-			name = is_unsigned ? "__umodti3" : "__modti3";
+			name = (char*)(is_unsigned ? "__umodti3" : "__modti3");
 		}
 		if (name != NULL) {
 			irValue **args = gb_alloc_array(proc->module->allocator, irValue *, 2);

--- a/src/ssa.cpp
+++ b/src/ssa.cpp
@@ -7,9 +7,6 @@ struct ssaProc;
 struct ssaEdge;
 struct ssaRegister;
 struct ssaTargetList;
-enum   ssaBlockKind;
-enum   ssaBranchPrediction;
-enum   ssaDeferExitKind;
 
 
 String ssa_mangle_name(ssaModule *m, String path, Entity *e);


### PR DESCRIPTION
Building the current version of Odin in linux results in this: https://hastebin.com/qulekonudu.lua. The diff shows the changes i had to make to get it to compile and run without segfaulting.

Each error one by one:
`In file included from src/main.cpp:5:
src/build_settings.cpp:144:2: error: C++ requires a type specifier for all declarations
        Array(char) path_buf;`
Changed to
`Array<char> path_buf;`
Next,
`In file included from src/main.cpp:9:
src/ssa.cpp:10:8: error: ISO C++ forbids forward references to 'enum' types
enum   ssaBlockKind;`
Required me to remove the forward declarations. Finally I had to explicitly cast the const C-strings in ir.cpp.

This compiled successfully, but segfaulted on the demo. Turned out `when` is broken, and it loads the sys/windows.odin even in linux. Commenting out the relevant line in os.odin made it run successfully. 

