### PR TITLE
Improve building Odin on Linux.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,44 @@
 #!/bin/bash
+#
+# NOTE:  POSIX prefers 'printf' over 'echo'.
+
+missing_llvm=0
+missing_clang=0
+
+# Check if LLVM is installed on system
+if ! hash llvm-ar 2> /dev/null; then
+    printf "[ERROR]  LLVM component not found:  llvm-ar\n"
+    missing_llvm=1
+fi
+if ! hash llvm-as 2> /dev/null; then
+    printf "[ERROR]  LLVM component not found:  llvm-as\n"
+    missing_llvm=1
+fi
+
+# Check if clang is installed on system
+if ! hash clang 2> /dev/null; then
+    printf "[ERROR]  Clang compiler not found:  clang\n"
+    missing_clang=1
+fi
+
+if [ $missing_llvm -eq 1 -a $missing_clang -eq 0 ]; then
+    printf "\nIn Ubuntu run 'sudo apt install llvm'\n\n"
+    exit 1 
+fi
+
+if [ $missing_llvm -eq 0 -a $missing_clang -eq 1 ]; then
+    printf "\nIn Ubuntu run 'sudo apt install clang'\n\n"
+    exit 1 
+fi
+
+if [ $missing_llvm -eq 1 -a $missing_clang -eq 1 ]; then
+    printf "\nIn Ubuntu run 'sudo apt install llvm clang'\n\n"
+    exit 1 
+fi
 
 release_mode=0
 
-warnings_to_disable="-std=c++11 -g -Wno-switch -Wno-pointer-sign -Wno-tautological-constant-out-of-range-compare -Wno-tautological-compare -Wno-macro-redefined -Wno-writable-strings"
+warnings_to_disable="-std=c++11 -Wno-switch -Wno-pointer-sign -Wno-tautological-constant-out-of-range-compare -Wno-tautological-compare -Wno-macro-redefined -Wno-writable-strings"
 libraries="-pthread -ldl -lm -lstdc++"
 other_args=""
 compiler="clang"
@@ -19,4 +55,13 @@ if [[ "$(uname)" == "Darwin" ]]; then
 	other_args="${other_args} -liconv"
 fi
 
-${compiler} src/main.cpp ${warnings_to_disable} ${libraries} ${other_args} -o odin && ./odin run examples/demo.odin
+printf "LLVM & clang installed on system.\n"
+printf "Building Odin...\n\n"
+
+printf "${compiler} src/main.cpp ${warnings_to_disable} ${libraries} ${other_args} -o odin\n"
+${compiler} src/main.cpp ${warnings_to_disable} ${libraries} ${other_args} -o odin
+
+printf "\nTesting Odin...\n\n"
+printf "./odin run examples/demo.odin\n"
+./odin run examples/demo.odin
+

--- a/examples/demo.odin
+++ b/examples/demo.odin
@@ -561,12 +561,16 @@ threading_example :: proc() {
 
 
 main :: proc() {
-	when false {
+	
+    when false {
 		fmt.println("\n# general_stuff");              general_stuff();
 		fmt.println("\n# default_struct_values");      default_struct_values();
 		fmt.println("\n# union_type");                 union_type();
 		fmt.println("\n# parametric_polymorphism");    parametric_polymorphism();
 		fmt.println("\n# threading_example");          threading_example();
 	}
+    
+    fmt.println("\nOdin seems to be working.  Go forth and code!");
+    
 }
 


### PR DESCRIPTION
This commit adds detection of LLVM & clang in the Linux build script.

Turns out if LLVM is not installed, Odin itself will build fine, but upon compiling/running Odin programs, the following message occurs:

`sh: 1: opt: not found`

This commit prints install instructions for Ubuntu if clang or LLVM is not found.

(Tested on Ubuntu 17.04 which uses LLVM v4.0)