### PR TITLE
Fixed foreign import for linux. Modified .gitignore to ignore temp files and files in shared/. Added a Makefile for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,7 +257,17 @@ paket-files/
 builds/
 bin/
 *.exe
+*.obj
+*.pdb
 
 # - Linux/MacOS
 odin
 odin.dSYM
+
+
+# shared collection
+shared/
+
+# temp files
+* .ll
+*.bc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+DISABLED_WARNINGS=-Wno-switch -Wno-writable-strings -Wno-tautological-compare -Wno-macro-redefined #-Wno-pointer-sign -Wno-tautological-constant-out-of-range-compare  
+LDFLAGS=-pthread -ldl -lm -lstdc++
+CFLAGS=-std=c++11
+CC=clang
+
+OS=$(shell uname)
+
+ifeq ($(OS), DARWIN)
+	LDFLAGS=$(LDFLAGS) -liconv
+endif
+
+all: debug demo
+
+demo:
+	./odin run examples/demo.odin
+
+debug:
+	$(CC) src/main.cpp $(DISABLED_WARNINGS) $(CFLAGS) -g $(LDFLAGS) -o odin
+
+release:
+	$(CC) src/main.cpp $(DISABLED_WARNINGS) $(CFLAGS) -O3 -march=native $(LDFLAGS) -o odin
+	
+
+	

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-release_mode=0
+release_mode=$1
 
-warnings_to_disable="-std=c++11 -g -Wno-switch -Wno-pointer-sign -Wno-tautological-constant-out-of-range-compare -Wno-tautological-compare -Wno-macro-redefined -Wno-writable-strings"
+warnings_to_disable="-std=c++11 -Wno-switch -Wno-pointer-sign -Wno-tautological-constant-out-of-range-compare -Wno-tautological-compare -Wno-macro-redefined -Wno-writable-strings"
 libraries="-pthread -ldl -lm -lstdc++"
 other_args=""
 compiler="clang"
 
 if [ "$release_mode" -eq "0" ]; then
-	other_args="${other_args} -g -fno-inline-functions"
+	other_args="${other_args} -g
 fi
+if [ "$release_mode" -eq "1" ]; then
+	other_args="${other_args} -O3 -march=native
+fi
+
 if [[ "$(uname)" == "Darwin" ]]; then
 
 	# Set compiler to clang on MacOS


### PR DESCRIPTION
I made it so that `foreign import` now works in Linux for non-system libraries. Due to the lack of an "import library" in Linux, we must require the user to make sure that shared libraries (.so files) are visible to the executable. Static libraries (.a files) can be linked using their relative paths.

Example:
If the following file is in `Odin/shared/stb_odin/stb_image.odin`, then the following code

```go
when ODIN_OS == "windows" do foreign import stbi "lib/stb_image.lib"
when ODIN_OS == "linux" do foreign import stbi "lib/stb_image.a"
```
will work as intended. The functions will be linked into the executable at compile time and there are no dependencies. In this case, the `.lib` file in Windows is a static library. The .a file corresponds to `Odin/shared/stb_odin/lib/stb_image.a`.

On the other hand, if the lines are

```go
when ODIN_OS == "windows" do foreign import stbi "lib/stb_image.lib"
when ODIN_OS == "linux" do foreign import stbi "lib/stb_image.so"
```

then this will not work in Linux, because this hard codes the full path of the .so file into the executable, and it will fail to find the shared library if the .so file is moved or if you run the program on another computer. Windows works just fine, because it uses an "import library" at compile time. The .executable will expect to find `$(EXE_PATH)/lib/stb_image.so`. 

Finally, system libraries can be imported without a suffix: 

```go
when ODIN_OS == "windows" do foreign import stbi "system:stb_image.lib"
when ODIN_OS == "linux" do foreign import stbi "system:stb_image"
```

which will search for the library (be it .so or .a) in the system library search paths (/usr/lib typically). 